### PR TITLE
END-111 Fixed bad tomcat config

### DIFF
--- a/idp/src/main/tomcat/server.xml
+++ b/idp/src/main/tomcat/server.xml
@@ -50,9 +50,8 @@
                resourceName="UserDatabase"/>
       </Realm>
 
-      <Host name="localhost" appBase="webapps" unpackWARs="true" autoDeploy="false" >      
-        <Valve className="org.apache.catalina.valves.RemoteIpValve"
-               remoteIpHeader="X-Forwarded-For" />
+      <Host name="${tomcat.hostname}" appBase="webapps" unpackWARs="true" autoDeploy="false" >      
+        <Valve className="org.apache.catalina.valves.RemoteIpValve" remoteIpHeader="X-Forwarded-For" />
       </Host>
 
     </Engine>


### PR DESCRIPTION
The name attribute of the only Host element did not match the defaultHost
attribute of the Engine element (unless TOMCAT_HOSTNAME was set to
localhost).