### PR TITLE
END-144 Upgrading dependency to opensaml-ext

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,8 +47,8 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <java.version>1.8</java.version>
     
-    <shibboleth-base-package.version>1.1</shibboleth-base-package.version>
-    <opensaml.eidas.version>1.0.4</opensaml.eidas.version>
+    <shibboleth-base-package.version>1.1.1</shibboleth-base-package.version>
+    <opensaml.eidas.version>1.0.5</opensaml.eidas.version>
     <eidas-commons.version>1.0.1</eidas-commons.version>
     
     <lombok.version>1.16.8</lombok.version>
@@ -109,7 +109,7 @@
       <dependency>
         <groupId>se.litsec.sweid.idp</groupId>
         <artifactId>shibboleth-base-dependency-bom</artifactId>
-        <version>1.1</version>
+        <version>1.1.1</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>      


### PR DESCRIPTION
Version 0.9.2 of opensaml-ext fixes the bug where a threading issue led
to bad metadata in some cases.