### PR TITLE
END-213 Fixed bug where Shibboleth would re-use attributes values

### DIFF
--- a/idp/pom.xml
+++ b/idp/pom.xml
@@ -49,7 +49,7 @@
   <properties>
     <docker.image.prefix>docker.eidastest.se:5000</docker.image.prefix>
 
-    <shibboleth-base.version>1.3-SNAPSHOT</shibboleth-base.version>
+    <shibboleth-base.version>1.3.1</shibboleth-base.version>
     <custom-remoteip-valve.version>1.1.0</custom-remoteip-valve.version>
 
     <mockito.version>1.9.5</mockito.version>

--- a/idp/src/main/shibboleth/config/conf/authn/external-authn-mvc-beans.xml
+++ b/idp/src/main/shibboleth/config/conf/authn/external-authn-mvc-beans.xml
@@ -42,6 +42,7 @@
    -->
   <bean id="sweid.AbstractExternalAuthenticationController" class="se.litsec.shibboleth.idp.authn.controller.sweid.AbstractExternalAuthenticationController"
     abstract="true" 
+    p:sessionManager-ref="shibboleth.SessionManager"
     p:signSupportService-ref="eidas.SignSupportService"
     p:attributeToIdMapping-ref="sweid.SAML2AttributeNameToIdMapperService"    
     p:flowName="authn/External" />    

--- a/pom.xml
+++ b/pom.xml
@@ -101,7 +101,7 @@
       <dependency>
         <groupId>se.litsec.sweid.idp</groupId>
         <artifactId>shibboleth-base-bom</artifactId>
-        <version>1.3-SNAPSHOT</version>
+        <version>1.3.1</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -109,7 +109,7 @@
       <dependency>
         <groupId>se.litsec.sweid.idp</groupId>
         <artifactId>shibboleth-base-dependency-bom</artifactId>
-        <version>1.3-SNAPSHOT</version>
+        <version>1.3</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>      


### PR DESCRIPTION
Normally, this is what we want, but since we include attributes that are
different between each authentication (transactionId) we cannot have
that feature on.