### PR TITLE
END-264 Fixed validation of SubjectConfirmationData/Recipient

### DIFF
--- a/sp/pom.xml
+++ b/sp/pom.xml
@@ -5,6 +5,7 @@
 
   <artifactId>eidas-connector-sp</artifactId>
   <packaging>jar</packaging>
+  <version>1.3.3-SNAPSHOT</version>
 
   <parent>
     <groupId>se.elegnamnden.eidas.idp</groupId>

--- a/sp/src/main/java/se/elegnamnden/eidas/idp/connector/sp/impl/ResponseProcessorImpl.java
+++ b/sp/src/main/java/se/elegnamnden/eidas/idp/connector/sp/impl/ResponseProcessorImpl.java
@@ -343,7 +343,11 @@ public class ResponseProcessorImpl implements ResponseProcessor, InitializingBea
       .expectedIssuer(idpMetadata.getEntityID())
       .responseIssueInstant(response.getIssueInstant().getMillis())
       .validAudiences(entityID)
-      .validRecipients(input.getReceiveURL())
+      /*
+       * We add the entityID as a valid recipient also since Germany places the entityID in the
+       * SubjectConfirmation/Recipient field instead of the URL to which the response is sent.
+       */
+      .validRecipients(input.getReceiveURL(), entityID)
       .build();
 
     ValidationResult result = this.assertionValidator.validate(assertion, context);


### PR DESCRIPTION
Allows also entityID and not only the URL on which the response was
delivered.