### PR TITLE
1.5.1 release

### DIFF
--- a/dev-idp/pom.xml
+++ b/dev-idp/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>se.elegnamnden.eidas.idp</groupId>
     <artifactId>eidas-connector-base-parent</artifactId>
-    <version>1.5.1-SNAPSHOT</version>
+    <version>1.5.1</version>
   </parent>
 
   <name>eIDAS :: Swedish eIDAS connector - Devel</name>

--- a/idp/pom.xml
+++ b/idp/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>se.elegnamnden.eidas.idp</groupId>
     <artifactId>eidas-connector-base-parent</artifactId>
-    <version>1.5.1-SNAPSHOT</version>
+    <version>1.5.1</version>
   </parent>
 
   <name>eIDAS :: Swedish eIDAS connector</name>
@@ -103,17 +103,6 @@
       <artifactId>shibboleth-sweid-extensions</artifactId>
     </dependency>
 
-<!-- 
-    <dependency>
-      <groupId>javax.servlet</groupId>
-      <artifactId>javax.servlet-api</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>jstl</groupId>
-      <artifactId>jstl</artifactId>
-    </dependency>
--->
     <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>javax.servlet-api</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <groupId>se.elegnamnden.eidas.idp</groupId>
   <artifactId>eidas-connector-base-parent</artifactId>
   <packaging>pom</packaging>
-  <version>1.5.1-SNAPSHOT</version>
+  <version>1.5.1</version>
 
   <name>eIDAS :: Parent POM for the Swedish eIDAS connector</name>
   <description>Parent POM for the Swedish eIDAS connector IdP</description>

--- a/sp/pom.xml
+++ b/sp/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>se.elegnamnden.eidas.idp</groupId>
     <artifactId>eidas-connector-base-parent</artifactId>
-    <version>1.5.1-SNAPSHOT</version>
+    <version>1.5.1</version>
   </parent>
 
   <name>eIDAS :: Swedish eIDAS connector SP</name>


### PR DESCRIPTION
Upgraded to Shibboleth 3.4.3
- We are now using Shibboleth 3.4.3 and OpenSAML 3.4.2.

Resolved security issues
- All cookies are now marked as HTTP-only and secure.
- No 500-stack traces are displayed in the UI.
- Fixed JSTL 1.2 vulnerability
- Acted on a number of Snyk-reports concerning vulnerabilities on
dependencies.

Configured logging to be less verbose
- We now filter away Shib's error logging of things that we don't think
are errors.

Implemented "HideFromDiscovery"
- The connector now hides countries that are marked as
HideFromDiscovery in aggregated metadata
(https://refeds.org/category/hide-from-discovery).