### PR TITLE
fix: add missing id for test

### DIFF
--- a/idp/src/main/resources/templates/country-select.html
+++ b/idp/src/main/resources/templates/country-select.html
@@ -87,6 +87,7 @@
                   class="btn country-button"
                   type="submit"
                   name="selectedCountry"
+                  th:id="${'countryFlag_' + country.getCode()}"
                   th:value="${country.getCode()}"
                   th:disabled="${country.isDisabled()}"
               >


### PR DESCRIPTION
The automatic tests missed the country button `id`s, so I added them back.