### PR TITLE
IS-191 Metadata signing of SP metadata can now be disabled

### DIFF
--- a/idp/src/main/java/se/swedenconnect/eidas/connector/config/ConnectorCredentials.java
+++ b/idp/src/main/java/se/swedenconnect/eidas/connector/config/ConnectorCredentials.java
@@ -306,18 +306,18 @@ public class ConnectorCredentials {
   /**
    * Gets the metadata signing credential.
    *
-   * @return the {@link PkiCredential}
-   * @throws IllegalArgumentException if no credential is found
+   * @return the {@link PkiCredential}, or {@code null} if none is configured
    */
+  @Nullable
   public PkiCredential getSpMetadataSigningCredential() {
     final PkiCredential[] creds = { this.spMetadataSignCredential, this.spDefaultCredential,
-        this.metadataSignCredential, this.defaultCredential, this.spSignCredential, this.signCredential };
+        this.metadataSignCredential, this.defaultCredential };
     for (final PkiCredential c : creds) {
       if (c != null) {
         return c;
       }
     }
-    throw new IllegalArgumentException("No metadata signing credential is available");
+    return null;
   }
 
   /**

--- a/idp/src/main/java/se/swedenconnect/eidas/connector/config/EidasAuthenticationConfiguration.java
+++ b/idp/src/main/java/se/swedenconnect/eidas/connector/config/EidasAuthenticationConfiguration.java
@@ -263,7 +263,9 @@ public class EidasAuthenticationConfiguration {
       @Qualifier("connector.sp.metadata") final EntityDescriptor metadata) {
 
     final EntityDescriptorContainer container = new EntityDescriptorContainer(
-        metadata, new OpenSamlCredential(this.credentials.getSpMetadataSigningCredential()));
+        metadata, Optional.ofNullable(this.credentials.getSpMetadataSigningCredential())
+        .map(OpenSamlCredential::new)
+        .orElse(null));
     container.setValidity(this.properties.getEidas().getMetadata().getValidityPeriod());
     container.setSigningConfiguration(securityConfiguration.getSignatureSigningConfiguration());
 


### PR DESCRIPTION
By not supplying dedicated credential for metadata signing and not specifying a default credential, no signing will be performed.

Closes #191 